### PR TITLE
feat: Curate navigation and add local dev README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# rumaniel.github.io
+
+Personal Jekyll site powered by GitHub Pages + Actions.
+
+## Requirements
+
+- Ruby 3.2+ (Ruby 3.4 recommended)
+- Bundler
+
+## Quick start (local preview)
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+Open http://localhost:4000
+
+### Build only
+
+```bash
+bundle exec jekyll build
+```
+
+### Preview drafts
+
+```bash
+bundle exec jekyll serve --drafts
+```
+
+## Use cases
+
+### 1) Create a new post
+
+**Location:** `_posts/`
+
+**File name:**
+```
+YYYY-MM-DD-your-post-slug.md
+```
+
+**Example:**
+```yaml
+---
+layout: post
+title: "My First Post"
+description: "Short summary for SEO"
+date: 2026-02-18 10:00:00 +0900
+categories: [unity, c#]
+tags: [jekyll, github-pages]
+---
+
+Your content starts here.
+```
+
+### 2) Create a new page (like About)
+
+**Location:** repository root (same level as `about.md`)
+
+**Example:** `new-page.md`
+```yaml
+---
+layout: page
+title: New Page
+permalink: /new-page/
+---
+
+Content goes here.
+```
+
+### 3) Update navigation items
+
+Navigation is controlled in:
+```
+_data/navigation.yml
+```
+
+Example:
+```yaml
+- title: About
+  url: /about/
+
+- title: Categories
+  url: /categories/
+```
+
+### 4) Categories archive
+
+Category archive pages are generated at:
+```
+/archives/<category>/
+```
+
+The hub page is:
+```
+/categories/
+```
+
+If you add a new category in a post, it will appear automatically.
+
+## Tips
+
+- Restart `jekyll serve` after changing `_config.yml`.
+- Do not commit `_site/` (build output).

--- a/_config.yml
+++ b/_config.yml
@@ -37,16 +37,10 @@ plugins:
 # Requires Actions build environment (not standard Pages gem)
 jekyll-archives:
   enabled:
-    - year
-    - month
-    - categories
+    - categories  # Category-based archives only (cleaner than year/month)
   layouts:
-    year: archive
-    month: archive
     category: archive
   permalinks:
-    year: /archives/:year/
-    month: /archives/:year/:month/
     category: /archives/:name/
 
 # --- Misc --- #

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,7 @@
+# Main navigation menu
+# Only explicitly listed items will appear in header
+- title: About
+  url: /about/
+
+- title: Categories
+  url: /categories/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,35 @@
+<header class="site-header" role="banner">
+  <div class="wrapper">
+    <div class="site-header-inner">
+      {% if site.logo %}
+        <a class="site-logo" href="{{ "/" | relative_url }}" rel="home">
+          <img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" />
+        </a>
+      {% else %}
+        <a class="site-title" rel="home" href="{{ "/" | relative_url }}">
+          {{ site.title | escape }}
+        </a>
+      {% endif %}
+
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,11.994,18,12.585,18,13.516L18,13.516z" />
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          <!-- Navigation items from _data/navigation.yml -->
+          {% for item in site.data.navigation %}
+            <a class="page-link" href="{{ item.url | relative_url }}">
+              {{ item.title }}
+            </a>
+          {% endfor %}
+        </div>
+      </nav>
+    </div>
+  </div>
+</header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,25 +9,32 @@ layout: default
 
 {{ content }}
 
-<div class="post-list">
-  {% for post in site.posts %}
-    <article class="post-card">
-      <div class="post-meta">
-        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
-        {% if post.categories and post.categories.size > 0 %}
-          <span class="post-categories">{{ post.categories | join: ", " }}</span>
+<section class="posts-section">
+  <div class="posts-header">
+    <h2 class="posts-title">Latest Articles</h2>
+    <p class="posts-count">{{ site.posts | size }} articles</p>
+  </div>
+  
+  <div class="post-list">
+    {% for post in site.posts %}
+      <article class="post-card">
+        <div class="post-meta">
+          <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
+          {% if post.categories and post.categories.size > 0 %}
+            <span class="post-categories">{{ post.categories | join: ", " }}</span>
+          {% endif %}
+        </div>
+        <h3 class="post-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </h3>
+        {% if post.excerpt %}
+          <p class="post-excerpt">{{ post.excerpt | strip_html | truncate: 220 }}</p>
         {% endif %}
-      </div>
-      <h2 class="post-title">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      </h2>
-      {% if post.excerpt %}
-        <p class="post-excerpt">{{ post.excerpt | strip_html | truncate: 220 }}</p>
-      {% endif %}
-      <div class="post-footer">
-        <span class="reading-time">{% include reading-time.html content=post.content %}</span>
-        <a class="post-readmore" href="{{ post.url | relative_url }}">Read</a>
-      </div>
-    </article>
-  {% endfor %}
-</div>
+        <div class="post-footer">
+          <span class="reading-time">{% include reading-time.html content=post.content %}</span>
+          <a class="post-readmore" href="{{ post.url | relative_url }}">Read</a>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</section>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -54,10 +54,43 @@ a {
 	font-size: 1.1rem;
 }
 
+/* Posts Section - Framed Container */
+.posts-section {
+	margin: 3rem 0;
+	padding: 2.5rem;
+	border-radius: var(--radius);
+	border: 1px solid var(--card-border);
+	background: linear-gradient(140deg, #ffffff 0%, #fafafa 100%);
+	box-shadow: var(--shadow);
+}
+
+.posts-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1rem;
+	margin-bottom: 2rem;
+	padding-bottom: 1.5rem;
+	border-bottom: 2px solid var(--card-border);
+}
+
+.posts-title {
+	margin: 0;
+	font-size: 1.5rem;
+	font-family: "IBM Plex Serif", "Times New Roman", serif;
+	color: var(--ink);
+	letter-spacing: -0.01em;
+}
+
+.posts-count {
+	margin: 0;
+	color: var(--muted);
+	font-size: 0.95rem;
+}
+
 .post-list {
 	display: grid;
 	gap: 1.5rem;
-	margin: 2rem 0 3rem;
 }
 
 .post-card {
@@ -227,6 +260,21 @@ a {
 
 	.home-subtitle {
 		font-size: 1rem;
+	}
+
+	.posts-section {
+		padding: 1.75rem;
+		margin: 2rem 0;
+	}
+
+	.posts-header {
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.posts-title {
+		font-size: 1.3rem;
 	}
 
 	.post-card {

--- a/categories.md
+++ b/categories.md
@@ -1,0 +1,145 @@
+---
+layout: page
+title: Categories
+permalink: /categories/
+description: Browse articles by category
+---
+
+<div class="categories-hero">
+  <h1 class="categories-title">Categories</h1>
+  <p class="categories-subtitle">Browse all articles organized by topic</p>
+</div>
+
+<section class="categories-section">
+  <div class="categories-grid">
+    {% assign sorted_categories = site.categories | sort %}
+    {% for category in sorted_categories %}
+      {% capture category_name %}{{ category[0] }}{% endcapture %}
+      {% capture category_posts_count %}{{ category[1] | size }}{% endcapture %}
+      <a href="/archives/{{ category_name | slugify }}/" class="category-card">
+        <div class="category-content">
+          <h3 class="category-name">{{ category_name | capitalize }}</h3>
+          <span class="category-count">
+            {{ category_posts_count }} 
+            {%- if category_posts_count == '1' %} article{% else %} articles{% endif -%}
+          </span>
+        </div>
+        <div class="category-arrow">→</div>
+      </a>
+    {% endfor %}
+  </div>
+</section>
+
+<style>
+.categories-hero {
+  margin: 2.5rem 0 2rem;
+  padding: 2.5rem 2.75rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+  background: linear-gradient(140deg, #f8f8f8, #ffffff 70%);
+  box-shadow: var(--shadow);
+}
+
+.categories-title {
+  margin-bottom: 0.5rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-family: "IBM Plex Serif", "Times New Roman", serif;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.categories-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.categories-section {
+  margin: 3rem 0;
+}
+
+.categories-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.category-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+  background: var(--card);
+  box-shadow: var(--shadow);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.category-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 20px 50px rgba(47, 47, 47, 0.12);
+  transform: translateY(-2px);
+}
+
+.category-content {
+  flex: 1;
+}
+
+.category-name {
+  margin: 0 0 0.6rem;
+  font-size: 1.2rem;
+  font-family: "IBM Plex Serif", "Times New Roman", serif;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.category-count {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--card-border);
+  background: #f7f7f7;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.category-arrow {
+  margin-left: 1rem;
+  color: var(--accent);
+  font-size: 1.3rem;
+  font-weight: 500;
+}
+
+@media (max-width: 720px) {
+  .categories-hero {
+    padding: 1.75rem;
+  }
+
+  .categories-title {
+    font-size: clamp(1.8rem, 8vw, 2.4rem);
+  }
+
+  .categories-subtitle {
+    font-size: 1rem;
+  }
+
+  .categories-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+  }
+
+  .category-card {
+    padding: 1.25rem;
+  }
+
+  .category-name {
+    font-size: 1.05rem;
+  }
+
+  .category-arrow {
+    margin-left: 0.5rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Overview\n\n- Add README with local preview and common edit use cases\n- Curate header navigation to About + Categories only\n- Add Categories hub page and data-driven nav\n\n## Why\n\n- Navigation was cluttered by auto-generated archive pages\n- Provide a clean entrypoint for local testing and edits\n\n## Test\n\n- bundle exec jekyll build\n- bundle exec jekyll serve (manual check)\n\n## Notes\n\n- _site/ is not committed\n